### PR TITLE
Only include backports/basic_object if BasicObject is missing.

### DIFF
--- a/spec/spec_helper_integration.rb
+++ b/spec/spec_helper_integration.rb
@@ -1,7 +1,7 @@
 ROOT = File.expand_path('../..', __FILE__)
 
 require 'backports'
-require 'backports/basic_object'
+require 'backports/basic_object' unless defined?(BasicObject)
 require 'rubygems'
 
 begin


### PR DESCRIPTION
This was causing jRuby 1.7.0 with 1.9 mode to fail running specs.
