### PR TITLE
Update a minor comment

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-# SimpleCov MUST be started before require 'ROM'
+# SimpleCov MUST be started before require 'rom-mapper'
 #
 if ENV['COVERAGE'] == 'true'
   require 'simplecov'


### PR DESCRIPTION
In a previous mass rename, I renamed "dm-mapper" by "ROM" in a comment. Maybe "rom-mapper" is preferable.
