### PR TITLE
Introduce ROM::Schema

### DIFF
--- a/config/flay.yml
+++ b/config/flay.yml
@@ -1,3 +1,3 @@
 ---
 threshold: 13
-total_score: 353
+total_score: 370

--- a/config/yardstick.yml
+++ b/config/yardstick.yml
@@ -1,2 +1,2 @@
 ---
-threshold: 93.6
+threshold: 93.3

--- a/lib/rom-relation.rb
+++ b/lib/rom-relation.rb
@@ -34,6 +34,7 @@ end # module ROM
 require 'rom/repository'
 require 'rom/environment'
 require 'rom/relation'
+require 'rom/schema'
 
 require 'rom/header'
 require 'rom/header/attribute_index'

--- a/lib/rom-relation.rb
+++ b/lib/rom-relation.rb
@@ -34,7 +34,11 @@ end # module ROM
 require 'rom/repository'
 require 'rom/environment'
 require 'rom/relation'
+
 require 'rom/schema'
+require 'rom/schema/definition'
+require 'rom/schema/definition/relation'
+require 'rom/schema/definition/relation/base'
 
 require 'rom/header'
 require 'rom/header/attribute_index'

--- a/lib/rom/schema.rb
+++ b/lib/rom/schema.rb
@@ -1,7 +1,6 @@
 module ROM
 
   class Schema
-
     include Concord.new(:relations)
     include Adamantium
 
@@ -13,80 +12,6 @@ module ROM
       relations[name]
     end
 
-    class Definition
-
-      class Relation
-
-        class Base < self
-
-          attr_reader :repository
-
-          def repository(name)
-            @repository = name
-          end
-        end
-
-        include Equalizer.new(:header, :keys)
-
-        def initialize(&block)
-          @header = []
-          @keys   = []
-          instance_eval(&block) if block
-        end
-
-        def header
-          Axiom::Relation::Header.coerce(@header, :keys => @keys)
-        end
-
-        def attribute(name, type)
-          @header << [name, type]
-          self
-        end
-
-        def key(*attribute_names)
-          @keys << attribute_names
-          self
-        end
-
-      end # class Relation
-
-      include Equalizer.new(:relations)
-
-      def self.relations(&block)
-        new(&block).relations
-      end
-
-      attr_reader :relations
-
-      def initialize(&block)
-        @relations = {}
-        instance_eval(&block) if block
-      end
-
-      def base_relation(name, &block)
-        header = Relation::Base.new(&block).header
-        relations[name] = Axiom::Relation::Base.new(name, header)
-        self
-      end
-
-      def relation(name, &block)
-        relations[name] = instance_eval(&block)
-        self
-      end
-
-      def [](name)
-        relations[name]
-      end
-
-      def method_missing(name, *args, &block)
-        return super unless relations.key?(name)
-        relations[name]
-      end
-
-      def respond_to?(name)
-        super || relations.key?(name)
-      end
-
-    end # class Definition
   end # class Schema
+
 end # module ROM

--- a/lib/rom/schema.rb
+++ b/lib/rom/schema.rb
@@ -6,7 +6,7 @@ module ROM
     include Adamantium
 
     def self.build(&block)
-      new(Definition.new(&block).relations)
+      new(Definition.relations(&block))
     end
 
     def [](name)
@@ -42,6 +42,10 @@ module ROM
       end # class Relation
 
       include Equalizer.new(:relations)
+
+      def self.relations(&block)
+        new(&block).relations
+      end
 
       attr_reader :relations
 

--- a/lib/rom/schema.rb
+++ b/lib/rom/schema.rb
@@ -1,0 +1,79 @@
+module ROM
+
+  class Schema
+
+    include Concord.new(:relations)
+    include Adamantium
+
+    def self.build(&block)
+      new(Definition.new(&block).relations)
+    end
+
+    def [](name)
+      relations[name]
+    end
+
+    class Definition
+
+      class Relation
+
+        include Equalizer.new(:header, :keys)
+
+        def initialize(&block)
+          @header = []
+          @keys   = []
+          instance_eval(&block) if block
+        end
+
+        def header
+          Axiom::Relation::Header.coerce(@header, :keys => @keys)
+        end
+
+        def attribute(name, type)
+          @header << [name, type]
+          self
+        end
+
+        def key(*attribute_names)
+          @keys << attribute_names
+          self
+        end
+
+      end # class Relation
+
+      include Equalizer.new(:relations)
+
+      attr_reader :relations
+
+      def initialize(&block)
+        @relations = {}
+        instance_eval(&block) if block
+      end
+
+      def base_relation(name, &block)
+        relation = Relation.new(&block)
+        relations[name] = Axiom::Relation::Base.new(name, relation.header)
+        self
+      end
+
+      def relation(name, &block)
+        relations[name] = instance_eval(&block)
+        self
+      end
+
+      def [](name)
+        relations[name]
+      end
+
+      def method_missing(name, *args, &block)
+        return super unless relations.key?(name)
+        relations[name]
+      end
+
+      def respond_to?(name)
+        super || relations.key?(name)
+      end
+
+    end # class Definition
+  end # class Schema
+end # module ROM

--- a/lib/rom/schema.rb
+++ b/lib/rom/schema.rb
@@ -17,6 +17,15 @@ module ROM
 
       class Relation
 
+        class Base < self
+
+          attr_reader :repository
+
+          def repository(name)
+            @repository = name
+          end
+        end
+
         include Equalizer.new(:header, :keys)
 
         def initialize(&block)
@@ -55,8 +64,8 @@ module ROM
       end
 
       def base_relation(name, &block)
-        relation = Relation.new(&block)
-        relations[name] = Axiom::Relation::Base.new(name, relation.header)
+        header = Relation::Base.new(&block).header
+        relations[name] = Axiom::Relation::Base.new(name, header)
         self
       end
 

--- a/lib/rom/schema/definition.rb
+++ b/lib/rom/schema/definition.rb
@@ -1,0 +1,45 @@
+module ROM
+  class Schema
+
+    class Definition
+      include Equalizer.new(:relations)
+
+      def self.relations(&block)
+        new(&block).relations
+      end
+
+      attr_reader :relations
+
+      def initialize(&block)
+        @relations = {}
+        instance_eval(&block) if block
+      end
+
+      def base_relation(name, &block)
+        header = Relation::Base.new(&block).header
+        relations[name] = Axiom::Relation::Base.new(name, header)
+        self
+      end
+
+      def relation(name, &block)
+        relations[name] = instance_eval(&block)
+        self
+      end
+
+      def [](name)
+        relations[name]
+      end
+
+      def method_missing(name, *args, &block)
+        return super unless relations.key?(name)
+        relations[name]
+      end
+
+      def respond_to?(name)
+        super || relations.key?(name)
+      end
+
+    end # Definition
+
+  end # Schema
+end # ROM

--- a/lib/rom/schema/definition/relation.rb
+++ b/lib/rom/schema/definition/relation.rb
@@ -21,7 +21,7 @@ module ROM
         end
 
         def key(*attribute_names)
-          @keys << attribute_names
+          @keys.concat(attribute_names)
           self
         end
 

--- a/lib/rom/schema/definition/relation.rb
+++ b/lib/rom/schema/definition/relation.rb
@@ -1,0 +1,32 @@
+module ROM
+  class Schema
+    class Definition
+
+      class Relation
+        include Equalizer.new(:header, :keys)
+
+        def initialize(&block)
+          @header = []
+          @keys   = []
+          instance_eval(&block) if block
+        end
+
+        def header
+          Axiom::Relation::Header.coerce(@header, :keys => @keys)
+        end
+
+        def attribute(name, type)
+          @header << [name, type]
+          self
+        end
+
+        def key(*attribute_names)
+          @keys << attribute_names
+          self
+        end
+
+      end # class Relation
+
+    end # class Definition
+  end # class Schema
+end # module ROM

--- a/lib/rom/schema/definition/relation/base.rb
+++ b/lib/rom/schema/definition/relation/base.rb
@@ -1,0 +1,19 @@
+module ROM
+  class Schema
+    class Definition
+      class Relation
+
+        class Base < self
+
+          attr_reader :repository
+
+          def repository(name)
+            @repository = name
+          end
+
+        end # Base
+
+      end # Relation
+    end # Definition
+  end # Schema
+end # ROM

--- a/spec/integration/schema_definition_spec.rb
+++ b/spec/integration/schema_definition_spec.rb
@@ -1,0 +1,89 @@
+require 'spec_helper'
+
+shared_examples_for 'a rom schema definition' do
+  specify 'registers the people relation' do
+    expect(schema[:people]).to eql(people)
+  end
+
+  specify 'registers the profiles relation' do
+    expect(schema[:profiles]).to eql(profiles)
+  end
+
+  specify 'registers the people_with_profile relation' do
+    expect(schema[:people_with_profile]).to eql(people_with_profile)
+  end
+end
+
+describe 'Defining a ROM::Schema' do
+
+  let(:people)              { Axiom::Relation::Base.new(:people, people_header) }
+  let(:people_header)       { Axiom::Relation::Header.coerce(people_attributes, :keys => people_keys) }
+  let(:people_attributes)   { [ [ :id, Integer ], [ :name, String ] ] }
+  let(:people_keys)         { [ :id ] }
+
+  let(:profiles)            { Axiom::Relation::Base.new(:profiles, profiles_header) }
+  let(:profiles_header)     { Axiom::Relation::Header.coerce(profiles_attributes, :keys => profiles_keys) }
+  let(:profiles_attributes) { [ [ :id, Integer ], [ :person_id, Integer ], [ :text, String ] ] }
+  let(:profiles_keys)       { [ [ :id ], [ :person_id ] ] }
+
+  let(:people_with_profile) { people.join(profiles.rename(:id => :profile_id, :person_id => :id)) }
+
+  context 'using ROM::Schema.build' do
+    it_behaves_like 'a rom schema definition' do
+      let(:schema) do
+        ROM::Schema.build do
+
+          base_relation :people do
+            attribute :id,   Integer
+            attribute :name, String
+
+            key :id
+          end
+
+          base_relation :profiles do
+            attribute :id,        Integer
+            attribute :person_id, Integer
+            attribute :text,      String
+
+            key :id
+            key :person_id
+          end
+
+          relation :people_with_profile do
+            people.join(profiles.rename(:id => :profile_id, :person_id => :id))
+          end
+        end
+      end
+    end
+  end
+
+  context 'using ROM::Schema::Definition' do
+    it_behaves_like 'a rom schema definition' do
+      let(:schema) do
+        definition = ROM::Schema::Definition.new
+
+        definition.base_relation :people do
+          attribute :id,   Integer
+          attribute :name, String
+
+          key :id
+        end
+
+        definition.base_relation :profiles do
+          attribute :id,        Integer
+          attribute :person_id, Integer
+          attribute :text,      String
+
+          key :id
+          key :person_id
+        end
+
+        definition.relation :people_with_profile do
+          people.join(profiles.rename(:id => :profile_id, :person_id => :id))
+        end
+
+        ROM::Schema.new(definition.relations)
+      end
+    end
+  end
+end

--- a/spec/integration/schema_definition_spec.rb
+++ b/spec/integration/schema_definition_spec.rb
@@ -34,6 +34,8 @@ describe 'Defining a ROM::Schema' do
         ROM::Schema.build do
 
           base_relation :people do
+            repository :postgres
+
             attribute :id,   Integer
             attribute :name, String
 
@@ -41,6 +43,8 @@ describe 'Defining a ROM::Schema' do
           end
 
           base_relation :profiles do
+            repository :postgres
+
             attribute :id,        Integer
             attribute :person_id, Integer
             attribute :text,      String

--- a/spec/integration/schema_definition_spec.rb
+++ b/spec/integration/schema_definition_spec.rb
@@ -9,7 +9,7 @@ describe 'Defining a ROM schema' do
   let(:profiles)            { Axiom::Relation::Base.new(:profiles, profiles_header) }
   let(:profiles_header)     { Axiom::Relation::Header.coerce(profiles_attributes, :keys => profiles_keys) }
   let(:profiles_attributes) { [ [ :id, Integer ], [ :person_id, Integer ], [ :text, String ] ] }
-  let(:profiles_keys)       { [ [ :id ], [ :person_id ] ] }
+  let(:profiles_keys)       { [ :id, :person_id ] }
 
   let(:people_with_profile) { people.join(profiles.rename(:id => :profile_id, :person_id => :id)) }
 
@@ -43,6 +43,14 @@ describe 'Defining a ROM schema' do
 
   it 'registers the people relation' do
     expect(schema[:people]).to eql(people)
+  end
+
+  it 'establishes key attributes for people relation' do
+    expect(schema[:people].header.keys.flat_map { |h| h.map(&:name) }).to eq(people_keys)
+  end
+
+  it 'establishes key attributes for profiles relation' do
+    expect(schema[:profiles].header.keys.flat_map { |h| h.map(&:name) }).to eq(profiles_keys)
   end
 
   it 'registers the profiles relation' do

--- a/spec/integration/schema_definition_spec.rb
+++ b/spec/integration/schema_definition_spec.rb
@@ -1,21 +1,6 @@
 require 'spec_helper'
 
-shared_examples_for 'a rom schema definition' do
-  specify 'registers the people relation' do
-    expect(schema[:people]).to eql(people)
-  end
-
-  specify 'registers the profiles relation' do
-    expect(schema[:profiles]).to eql(profiles)
-  end
-
-  specify 'registers the people_with_profile relation' do
-    expect(schema[:people_with_profile]).to eql(people_with_profile)
-  end
-end
-
-describe 'Defining a ROM::Schema' do
-
+describe 'Defining a ROM schema' do
   let(:people)              { Axiom::Relation::Base.new(:people, people_header) }
   let(:people_header)       { Axiom::Relation::Header.coerce(people_attributes, :keys => people_keys) }
   let(:people_attributes)   { [ [ :id, Integer ], [ :name, String ] ] }
@@ -28,66 +13,43 @@ describe 'Defining a ROM::Schema' do
 
   let(:people_with_profile) { people.join(profiles.rename(:id => :profile_id, :person_id => :id)) }
 
-  context 'using ROM::Schema.build' do
-    it_behaves_like 'a rom schema definition' do
-      let(:schema) do
-        ROM::Schema.build do
+  let(:schema) do
+    ROM::Schema.build do
+      base_relation :people do
+        repository :postgres
 
-          base_relation :people do
-            repository :postgres
+        attribute :id,   Integer
+        attribute :name, String
 
-            attribute :id,   Integer
-            attribute :name, String
+        key :id
+      end
 
-            key :id
-          end
+      base_relation :profiles do
+        repository :postgres
 
-          base_relation :profiles do
-            repository :postgres
+        attribute :id,        Integer
+        attribute :person_id, Integer
+        attribute :text,      String
 
-            attribute :id,        Integer
-            attribute :person_id, Integer
-            attribute :text,      String
+        key :id
+        key :person_id
+      end
 
-            key :id
-            key :person_id
-          end
-
-          relation :people_with_profile do
-            people.join(profiles.rename(:id => :profile_id, :person_id => :id))
-          end
-        end
+      relation :people_with_profile do
+        people.join(profiles.rename(:id => :profile_id, :person_id => :id))
       end
     end
   end
 
-  context 'using ROM::Schema::Definition' do
-    it_behaves_like 'a rom schema definition' do
-      let(:schema) do
-        definition = ROM::Schema::Definition.new
+  it 'registers the people relation' do
+    expect(schema[:people]).to eql(people)
+  end
 
-        definition.base_relation :people do
-          attribute :id,   Integer
-          attribute :name, String
+  it 'registers the profiles relation' do
+    expect(schema[:profiles]).to eql(profiles)
+  end
 
-          key :id
-        end
-
-        definition.base_relation :profiles do
-          attribute :id,        Integer
-          attribute :person_id, Integer
-          attribute :text,      String
-
-          key :id
-          key :person_id
-        end
-
-        definition.relation :people_with_profile do
-          people.join(profiles.rename(:id => :profile_id, :person_id => :id))
-        end
-
-        ROM::Schema.new(definition.relations)
-      end
-    end
+  it 'registers the people_with_profile relation' do
+    expect(schema[:people_with_profile]).to eql(people_with_profile)
   end
 end


### PR DESCRIPTION
References: #55 

Opening early for discussion. As long as we don't need a graph (because we have no relationships), let's start flat and simple. Everything is up for debate.

I could imagine adding a `ROM::Schema::Definition#reference` method which would create something like a `ROM::Reference` object. This would basically encapsulate all that's needed for an FK constraint.

Once `ROM::Schema#references` is added, we basically have all the information we need for "strongly connected nodes" (aka edges in a graph, aka `many_to_one` - and if we go bidirectional - `one_to_one` (FK is unique) or `one_to_many` (FK is not unique) relationships). "Weakly connected nodes" (aka `many_to_many` relationships) can imo be built on top of those (by walking along a chain of strongly connected nodes).

Also note that the current implementation wraps `Axiom::Relation` instances. That's the right thing to do imo. I have a few ideas how to support both schemas containing axiom and/or rom relations. I will outline them tomorrow.
