### PR TITLE
[WIP] relation mapping support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :test do
   gem 'bogus', '~> 0.1'
   gem 'randexp'
   gem 'ruby-graphviz'
-  gem 'rom-mapper',           git: 'https://github.com/rom-rb/rom-mapper.git'
+  gem 'rom-mapper',           git: 'https://github.com/rom-rb/rom-mapper.git', branch: 'relation-mapping-support'
   gem 'axiom-memory-adapter', git: 'https://github.com/dkubb/axiom-memory-adapter.git'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :test do
   gem 'bogus', '~> 0.1'
   gem 'randexp'
   gem 'ruby-graphviz'
-  gem 'rom-mapper',           git: 'https://github.com/rom-rb/rom-mapper.git', branch: 'relation-mapping-support'
+  gem 'rom-mapper',           git: 'https://github.com/rom-rb/rom-mapper.git'
   gem 'axiom-memory-adapter', git: 'https://github.com/dkubb/axiom-memory-adapter.git'
 end
 

--- a/config/flay.yml
+++ b/config/flay.yml
@@ -1,3 +1,3 @@
 ---
-threshold: 10
-total_score: 105
+threshold: 11
+total_score: 124

--- a/lib/rom-relation.rb
+++ b/lib/rom-relation.rb
@@ -2,6 +2,7 @@
 
 require 'addressable/uri'
 
+require 'set'
 require 'concord'
 require 'abstract_type'
 require 'descendants_tracker'
@@ -41,3 +42,4 @@ require 'rom/schema/definition/relation'
 require 'rom/schema/definition/relation/base'
 
 require 'rom/mapping'
+require 'rom/mapping/definition'

--- a/lib/rom-relation.rb
+++ b/lib/rom-relation.rb
@@ -39,3 +39,5 @@ require 'rom/schema'
 require 'rom/schema/definition'
 require 'rom/schema/definition/relation'
 require 'rom/schema/definition/relation/base'
+
+require 'rom/mapping'

--- a/lib/rom/mapping.rb
+++ b/lib/rom/mapping.rb
@@ -7,17 +7,27 @@ module ROM
     class Definition
 
       def self.build(header, &block)
-        new(header).instance_eval(&block).freeze
+        new(header, &block).freeze
       end
 
-      def initialize(header)
+      def initialize(header, &block)
         @header     = header
         @map        = {}
         @attributes = []
+        @mapper     = nil
+        instance_eval(&block)
       end
 
       def header
         Mapper::Header.build(project_header, map: mapping)
+      end
+
+      def mapper(mapper = Undefined)
+        if mapper == Undefined
+          @mapper
+        else
+          @mapper = mapper
+        end
       end
 
       def mapping
@@ -81,7 +91,7 @@ module ROM
     # @api private
     def build_relation(relation, &block)
       definition = Definition.build(relation.header, &block)
-      mapper     = Mapper.build(definition.header, definition.model)
+      mapper     = definition.mapper || Mapper.build(definition.header, definition.model)
 
       registry[relation.name] = Relation.build(relation, mapper)
     end

--- a/lib/rom/mapping.rb
+++ b/lib/rom/mapping.rb
@@ -17,7 +17,7 @@ module ROM
       end
 
       def header
-        @header.project(@attributes.concat(@map.keys))
+        Mapper::Header.build(project_header, map: mapping)
       end
 
       def mapping
@@ -42,6 +42,12 @@ module ROM
         end
 
         self
+      end
+
+      private
+
+      def project_header
+        @header.project(@attributes.concat(@map.keys))
       end
     end
 
@@ -75,8 +81,7 @@ module ROM
     # @api private
     def build_relation(relation, &block)
       definition = Definition.build(relation.header, &block)
-      header     = Mapper::Header.build(definition.header, map: definition.mapping)
-      mapper     = Mapper.build(header, definition.model)
+      mapper     = Mapper.build(definition.header, definition.model)
 
       registry[relation.name] = Relation.build(relation, mapper)
     end

--- a/lib/rom/mapping.rb
+++ b/lib/rom/mapping.rb
@@ -4,63 +4,6 @@ module ROM
 
   class Mapping
 
-    class Definition
-
-      def self.build(header, &block)
-        new(header, &block).freeze
-      end
-
-      def initialize(header, &block)
-        @header     = header
-        @map        = {}
-        @attributes = []
-        @mapper     = nil
-        instance_eval(&block)
-      end
-
-      def header
-        Mapper::Header.build(project_header, map: mapping)
-      end
-
-      def mapper(mapper = Undefined)
-        if mapper == Undefined
-          @mapper
-        else
-          @mapper = mapper
-        end
-      end
-
-      def mapping
-        @map
-      end
-
-      def model(model = Undefined)
-        if model == Undefined
-          @model
-        else
-          @model = model
-        end
-      end
-
-      def map(*args)
-        options = args.last
-
-        if options.is_a?(Hash)
-          @map.update(args.first => options[:to])
-        else
-          @attributes.concat(args)
-        end
-
-        self
-      end
-
-      private
-
-      def project_header
-        @header.project(@attributes.concat(@map.keys))
-      end
-    end
-
     attr_reader :env, :registry, :model
 
     # @api public

--- a/lib/rom/mapping.rb
+++ b/lib/rom/mapping.rb
@@ -7,14 +7,14 @@ module ROM
     attr_reader :env, :registry, :model
 
     # @api public
-    def self.build(env, &block)
-      new(env, &block).registry
+    def self.build(env, registry = {}, &block)
+      new(env, registry, &block).registry
     end
 
     # @api private
-    def initialize(env, &block)
+    def initialize(env, registry, &block)
       @env      = env
-      @registry = {}
+      @registry = registry
       instance_eval(&block)
     end
 

--- a/lib/rom/mapping.rb
+++ b/lib/rom/mapping.rb
@@ -2,10 +2,36 @@
 
 module ROM
 
+  # Builder DSL for ROM relations
+  #
   class Mapping
 
     attr_reader :env, :registry, :model
+    private :env, :model
 
+    # Build ROM relations
+    #
+    # @example
+    #   relation = Axiom::Relation::Base.new(:users, [[:id, Integer], [:user_name, String]])
+    #   env      = { users: relation }
+    #
+    #   User = Class.new(OpenStruct.new)
+    #
+    #   registry = Mapping.build(env) do
+    #     users do
+    #       map :id
+    #       map :user_name, to: :name
+    #     end
+    #   end
+    #
+    #   registry[:users]
+    #   # #<ROM::Relation:0x000000025d3160>
+    #
+    # @param [Environment, Hash] container with configured axiom relations
+    # @param [Hash] registry for rom relations
+    #
+    # @return [Hash]
+    #
     # @api public
     def self.build(env, registry = {}, &block)
       new(env, registry, &block).registry

--- a/lib/rom/mapping.rb
+++ b/lib/rom/mapping.rb
@@ -59,10 +59,8 @@ module ROM
 
     # @api private
     def build_relation(relation, &block)
-      definition = Definition.build(relation.header, &block)
-      mapper     = definition.mapper || Mapper.build(definition.header, definition.model)
-
-      registry[relation.name] = Relation.build(relation, mapper)
+      definition              = Definition.build(relation.header, &block)
+      registry[relation.name] = Relation.build(relation, definition.mapper)
     end
 
   end # Mapping

--- a/lib/rom/mapping.rb
+++ b/lib/rom/mapping.rb
@@ -1,0 +1,86 @@
+# encoding: utf-8
+
+module ROM
+
+  class Mapping
+
+    class Definition
+
+      def self.build(header, &block)
+        new(header).instance_eval(&block).freeze
+      end
+
+      def initialize(header)
+        @header     = header
+        @map        = {}
+        @attributes = []
+      end
+
+      def header
+        @header.project(@attributes.concat(@map.keys))
+      end
+
+      def mapping
+        @map
+      end
+
+      def model(model = Undefined)
+        if model == Undefined
+          @model
+        else
+          @model = model
+        end
+      end
+
+      def map(*args)
+        options = args.last
+
+        if options.is_a?(Hash)
+          @map.update(args.first => options[:to])
+        else
+          @attributes.concat(args)
+        end
+
+        self
+      end
+    end
+
+    attr_reader :env, :registry, :model
+
+    # @api public
+    def self.build(env, &block)
+      new(env, &block).registry
+    end
+
+    # @api private
+    def initialize(env, &block)
+      @env      = env
+      @registry = {}
+      instance_eval(&block)
+    end
+
+    private
+
+    # @api private
+    def method_missing(name, *args, &block)
+      relation = env[name]
+
+      if relation
+        build_relation(relation, &block)
+      else
+        super
+      end
+    end
+
+    # @api private
+    def build_relation(relation, &block)
+      definition = Definition.build(relation.header, &block)
+      header     = Mapper::Header.build(definition.header, map: definition.mapping)
+      mapper     = Mapper.build(header, definition.model)
+
+      registry[relation.name] = Relation.build(relation, mapper)
+    end
+
+  end # Mapping
+
+end # ROM

--- a/lib/rom/mapping/definition.rb
+++ b/lib/rom/mapping/definition.rb
@@ -3,6 +3,8 @@
 module ROM
   class Mapping
 
+    # Mapping definition DSL
+    #
     # @private
     class Definition
       include Adamantium::Flat
@@ -10,11 +12,17 @@ module ROM
       attr_reader :mapping, :attributes
       private :mapping, :attributes
 
+      # Build new mapping definition
+      #
       # @api private
       def self.build(header, &block)
         new(header, &block)
       end
 
+      # Initialize a new Definition instance
+      #
+      # @return [undefined]
+      #
       # @api private
       def initialize(header, &block)
         @header     = header
@@ -22,7 +30,10 @@ module ROM
         @attributes = Set.new
         @mapper     = nil
         @model      = nil
+
         instance_eval(&block)
+
+        build_mapper unless mapper
       end
 
       # @api private
@@ -31,7 +42,21 @@ module ROM
       end
       memoize :header
 
-      # @api private
+      # Get or set mapper
+      #
+      # @example
+      #
+      #   Mapping.build do
+      #     users do
+      #       mapper my_custom_mapper
+      #     end
+      #   end
+      #
+      # @param [Object]
+      #
+      # @return [Object]
+      #
+      # @api public
       def mapper(mapper = Undefined)
         if mapper == Undefined
           @mapper
@@ -40,7 +65,21 @@ module ROM
         end
       end
 
-      # @api private
+      # Set model for the mapper
+      #
+      # @example
+      #
+      #   Mapping.build do
+      #     users do
+      #       model User
+      #     end
+      #   end
+      #
+      # @param [Class]
+      #
+      # @return [Class]
+      #
+      # @api public
       def model(model = Undefined)
         if model == Undefined
           @model
@@ -49,7 +88,22 @@ module ROM
         end
       end
 
-      # @api private
+      # Configure attribute mappings
+      #
+      # @example
+      #
+      #   Mapping.build do
+      #     users do
+      #       map :id, :email
+      #       map :user_name, to: :name
+      #     end
+      #   end
+      #
+      # @params [Array<Symbol>,Symbol,Hash]
+      #
+      # @return [Definition]
+      #
+      # @api public
       def map(*args)
         options = args.last
 
@@ -64,9 +118,18 @@ module ROM
 
       private
 
+      # Project header using configured attributes
+      #
       # @api private
       def project_header
         @header.project(attributes + Set[*mapping.keys])
+      end
+
+      # Build default rom mapper
+      #
+      # @api private
+      def build_mapper
+        @mapper = Mapper.build(header, model)
       end
 
     end # Definition

--- a/lib/rom/mapping/definition.rb
+++ b/lib/rom/mapping/definition.rb
@@ -21,6 +21,7 @@ module ROM
         @mapping    = {}
         @attributes = Set.new
         @mapper     = nil
+        @model      = nil
         instance_eval(&block)
       end
 
@@ -65,7 +66,7 @@ module ROM
 
       # @api private
       def project_header
-        @header.project(attributes + Set[mapping.keys])
+        @header.project(attributes + Set[*mapping.keys])
       end
 
     end # Definition

--- a/lib/rom/mapping/definition.rb
+++ b/lib/rom/mapping/definition.rb
@@ -52,7 +52,7 @@ module ROM
       def map(*args)
         options = args.last
 
-        if options.is_a?(Hash)
+        if options.kind_of?(Hash)
           mapping.update(args.first => options[:to])
         else
           @attributes += Set[*args]

--- a/lib/rom/mapping/definition.rb
+++ b/lib/rom/mapping/definition.rb
@@ -1,0 +1,74 @@
+# encoding: utf-8
+
+module ROM
+  class Mapping
+
+    # @private
+    class Definition
+      include Adamantium::Flat
+
+      attr_reader :mapping, :attributes
+      private :mapping, :attributes
+
+      # @api private
+      def self.build(header, &block)
+        new(header, &block)
+      end
+
+      # @api private
+      def initialize(header, &block)
+        @header     = header
+        @mapping    = {}
+        @attributes = Set.new
+        @mapper     = nil
+        instance_eval(&block)
+      end
+
+      # @api private
+      def header
+        Mapper::Header.build(project_header, map: mapping)
+      end
+      memoize :header
+
+      # @api private
+      def mapper(mapper = Undefined)
+        if mapper == Undefined
+          @mapper
+        else
+          @mapper = mapper
+        end
+      end
+
+      # @api private
+      def model(model = Undefined)
+        if model == Undefined
+          @model
+        else
+          @model = model
+        end
+      end
+
+      # @api private
+      def map(*args)
+        options = args.last
+
+        if options.is_a?(Hash)
+          mapping.update(args.first => options[:to])
+        else
+          @attributes += Set[*args]
+        end
+
+        self
+      end
+
+      private
+
+      # @api private
+      def project_header
+        @header.project(attributes + Set[mapping.keys])
+      end
+
+    end # Definition
+
+  end # Mapping
+end # ROM

--- a/lib/rom/relation.rb
+++ b/lib/rom/relation.rb
@@ -46,6 +46,18 @@ module ROM
   class Relation
     include Enumerable, Concord::Public.new(:relation, :mapper)
 
+    # Build a new relation
+    #
+    # @param [Axiom::Relation]
+    # @param [Object] mapper
+    #
+    # @return [Relation]
+    #
+    # @api public
+    def self.build(relation, mapper)
+      new(mapper.call(relation), mapper)
+    end
+
     alias_method :all, :to_a
 
     # Iterate over tuples yielded by the wrapped relation

--- a/spec/integration/mapping_relations_spec.rb
+++ b/spec/integration/mapping_relations_spec.rb
@@ -28,7 +28,7 @@ describe 'Defining relation mappings' do
     Object.send(:remove_const, :User)
   end
 
-  specify 'building registry of mapped relations' do
+  specify 'building registry of automatically mapped relations' do
     registry = Mapping.build(env) {
       users do
         model User
@@ -41,6 +41,21 @@ describe 'Defining relation mappings' do
     users = registry[:users]
 
     jane = User.new(id: 1, name: 'Jane')
+
+    users.insert(jane)
+
+    expect(users.to_a).to eql([jane])
+  end
+
+  specify 'providing custom mapper' do
+    custom_model  = mock_model(:id, :user_name)
+    custom_mapper = TestMapper.new(schema[:users].header, custom_model)
+
+    registry = Mapping.build(env) { users { mapper(custom_mapper) } }
+
+    users = registry[:users]
+
+    jane = custom_model.new(id: 1, user_name: 'Jane')
 
     users.insert(jane)
 

--- a/spec/integration/mapping_relations_spec.rb
+++ b/spec/integration/mapping_relations_spec.rb
@@ -1,0 +1,35 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+describe 'Mapping relations' do
+  let!(:env)   { Environment.coerce(:test => 'memory://test') }
+  let!(:model) { mock_model(:id, :name) }
+
+  specify 'I can define a relation and its mapping' do
+    schema = Schema.build do
+      base_relation :users do
+        repository :test
+
+        attribute :id,        Integer
+        attribute :user_name, String
+
+        key :id
+      end
+    end
+
+    env.load_schema(schema)
+
+    # TODO: replace that with mapper DSL once ready
+    header = Mapper::Header.coerce(schema[:users].header, map: { user_name: :name })
+    mapper = Mapper.build(header, model)
+
+    users  = Relation.build(env.repository(:test).get(:users), mapper)
+
+    jane = model.new(id: 1, name: 'Jane')
+
+    users.insert(jane)
+
+    expect(users.to_a).to eql([jane])
+  end
+end

--- a/spec/integration/mapping_relations_spec.rb
+++ b/spec/integration/mapping_relations_spec.rb
@@ -21,7 +21,7 @@ describe 'Mapping relations' do
     env.load_schema(schema)
 
     # TODO: replace that with mapper DSL once ready
-    header = Mapper::Header.coerce(schema[:users].header, map: { user_name: :name })
+    header = Mapper::Header.build(schema[:users].header, map: { user_name: :name })
     mapper = Mapper.build(header, model)
 
     users  = Relation.build(env.repository(:test).get(:users), mapper)

--- a/spec/support/test_mapper.rb
+++ b/spec/support/test_mapper.rb
@@ -1,6 +1,11 @@
 # encoding: utf-8
 
 class TestMapper < Struct.new(:header, :model)
+
+  def call(relation)
+    relation
+  end
+
   def load(tuple)
     model.new(
       Hash[
@@ -14,4 +19,5 @@ class TestMapper < Struct.new(:header, :model)
       tuple << object.send(attribute.name)
     }
   end
+
 end

--- a/spec/unit/rom/mapping/class_methods/build_spec.rb
+++ b/spec/unit/rom/mapping/class_methods/build_spec.rb
@@ -1,0 +1,49 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+describe Mapping, '.build' do
+  let(:header)   { [[:id, Integer], [:user_name, String], [:age, Integer], [:email, String]] }
+  let(:relation) { Axiom::Relation::Base.new(:users, header) }
+  let(:env)      { Hash[users: relation] }
+  let(:registry) { Hash.new }
+
+  context 'when attribute mapping is used' do
+    subject do
+      Mapping.build(env, registry) do
+        users do
+          map :id, :email
+          map :user_name, to: :name
+        end
+      end
+    end
+
+    before do
+      stub(env).[](:users) { relation }
+    end
+
+    it 'registers rom relation' do
+      expect(subject[:users]).to be_instance_of(Relation)
+    end
+
+    it 'builds rom mapper' do
+      mapper = subject[:users].mapper
+
+      expect(mapper.header.map(&:name)).to eql([:id, :email, :name])
+    end
+  end
+
+  context 'when registry is not injected' do
+    subject { Mapping.build(env) { } }
+
+    it { should be_instance_of(Hash) }
+  end
+
+  context 'when unknown relation name is used' do
+    subject { described_class.build(env, registry) { not_here {} } }
+
+    it 'raises error' do
+      expect { subject }.to raise_error(NoMethodError)
+    end
+  end
+end

--- a/spec/unit/rom/relation/class_methods/new_spec.rb
+++ b/spec/unit/rom/relation/class_methods/new_spec.rb
@@ -1,0 +1,18 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+describe Relation, '.build' do
+  subject { described_class.build(relation, mapper) }
+
+  fake(:relation) { Axiom::Relation }
+  fake(:mapper)   { Mapper }
+
+  let(:mapped_relation) { mock('mapped_relation') }
+
+  before do
+    stub(mapper).call(relation) { mapped_relation }
+  end
+
+  its(:relation) { should be(mapped_relation) }
+end


### PR DESCRIPTION
This will add support for mapped relations. I'm still unsure where the DSL code should be located - here, in rom-mapper or maybe in rom.

The way I imagine it to work is that after you loaded the schema in the env you can call `Mapping.build(env) {}` to define how relations are mapped, you get a hash of mapped rom relations back. I think it has to support defining those mappings separately in multiple files, kinda like defining DM models in multiple files, because that will be a very common use case.

This leads to a missing object because right now `Environment` already has a registry of relations from all repositories, but those are axiom ones, not rom mapped relations. Which makes me think we need a separate `Registry` that will hold rom relations created via `Mapping.build`. You could create the registry yourself and pass it to the builder method as many times you want, this way we could have mappings defined in multiple files.

Please note that naming is a total WIP as well as implementation. Let me know if you think `Mapping` or `Registry` aren't good names.

Currently I made the DSL to look like this:

``` ruby
# this is what we already have
schema = Schema.build do
  base_relation :users do
    repository :test

    attribute :id, Integer
    attribute :user_name, string

    key :id
  end
end

env = Environment.coerce(test: 'memory://test').load_schema(schema)

# this is the new thing
registry = Mapping.build(env) do
  users do
    model User

    map :id
    map :user_name, to: :name
  end
end
```

^ this will build a rom relation and inject a rom mapper configured based on the mapping definition. I will also add a way to just provide your mapper instance or specify which loading strategies you want to use (we have 3 right now).

In general my motivation behind the DSL is to have it as slick as possible. I also want to add convenient methods to `Environment` so that you can define schema+mapping as quickly as possible, otherwise that will be a bit discouraging because in order to load a model from a db you need to 1) configure env 2) set up schema 3) load schema into env 4) define mappings which is obviously a great separation and will be used like that in, for example, rails integration _but_ in simple cases when you just want to get up and running quickly it will be an overkill (for instance think a dead-simple-one-file-sinatra-app).

Ugh, that was a bit too long, sorry about that but please let me know your thoughts :)

refs #59
