### PR TITLE
Adapter relations in schema

### DIFF
--- a/config/flay.yml
+++ b/config/flay.yml
@@ -1,3 +1,3 @@
 ---
 threshold: 11
-total_score: 124
+total_score: 120

--- a/lib/rom/environment.rb
+++ b/lib/rom/environment.rb
@@ -68,6 +68,11 @@ module ROM
       @schema
     end
 
+    # @api public
+    def mapping(&block)
+      Mapping.build(self, &block)
+    end
+
     # Return registered relation
     #
     # @example

--- a/lib/rom/environment.rb
+++ b/lib/rom/environment.rb
@@ -5,7 +5,7 @@ module ROM
   # The environment configures repositories and loads schema with relations
   #
   class Environment
-    include Concord::Public.new(:repositories, :registry)
+    include Concord.new(:repositories, :registry)
 
     # Coerce a repository config hash into an environment instance
     #
@@ -42,6 +42,27 @@ module ROM
     # @api private
     def self.build(repositories, registry = {})
       new(repositories, registry)
+    end
+
+    # Build a relation schema for this environment
+    #
+    # @example
+    #   env = Environment.coerce(test: 'memory://test')
+    #
+    #   env.schema do
+    #     base_relation :users do
+    #       repository :test
+    #
+    #       attribute :id, Integer
+    #       attribute :name, String
+    #     end
+    #   end
+    #
+    # @return [Schema]
+    #
+    # @api public
+    def schema(&block)
+      Schema.build(repositories, &block)
     end
 
     # Return registered relation

--- a/lib/rom/environment.rb
+++ b/lib/rom/environment.rb
@@ -62,14 +62,8 @@ module ROM
     #
     # @api public
     def schema(&block)
-      if block_given?
-        if @schema
-          @schema.call(&block)
-        else
-          @schema = Schema.build(repositories, &block)
-        end
-      end
-
+      @schema ||= Schema.build(repositories)
+      @schema.call(&block) if block
       @schema
     end
 

--- a/lib/rom/environment.rb
+++ b/lib/rom/environment.rb
@@ -122,7 +122,7 @@ module ROM
     # @return [Environment]
     #
     # @api private
-    def register(name, relation)
+    def []=(name, relation)
       registry[name] = relation
       self
     end

--- a/lib/rom/environment.rb
+++ b/lib/rom/environment.rb
@@ -5,7 +5,7 @@ module ROM
   # The environment configures repositories and loads schema with relations
   #
   class Environment
-    include Concord.new(:repositories, :registry)
+    include Concord::Public.new(:repositories, :registry)
 
     # Coerce a repository config hash into an environment instance
     #
@@ -59,30 +59,13 @@ module ROM
       registry[name]
     end
 
-    # Load defined schema and register relations
-    #
-    # @example
-    #
-    #   schema = Schema.build do
-    #     base_relation :users do
-    #       repository :test
-    #
-    #       attributes :id, :name, :email
-    #     end
-    #   end
-    #
-    #   env = Environment.coerce(test: 'memory://test').load_schema(schema)
-    #
-    # @param [Schema] schema
+    # Register a rom relation
     #
     # @return [Environment]
     #
-    # @api public
-    def load_schema(schema)
-      schema.each do |repository_name, relations|
-        register_relations(repository_name, relations)
-      end
-
+    # @api private
+    def register(name, relation)
+      registry[name] = relation
       self
     end
 
@@ -93,22 +76,6 @@ module ROM
     # @api private
     def repository(name)
       repositories[name]
-    end
-
-    private
-
-    # Register relations in a repository
-    #
-    # @return [Environment]
-    #
-    # @api private
-    def register_relations(repository_name, relations)
-      relations.each do |relation|
-        name           = relation.name
-        repository     = repository(repository_name).register(name, relation)
-        registry[name] = repository.get(name)
-      end
-      self
     end
 
   end # Environment

--- a/lib/rom/environment.rb
+++ b/lib/rom/environment.rb
@@ -63,8 +63,13 @@ module ROM
     # @api public
     def schema(&block)
       if block_given?
-        @schema = Schema.build(repositories, &block)
+        if @schema
+          @schema.call(&block)
+        else
+          @schema = Schema.build(repositories, &block)
+        end
       end
+
       @schema
     end
 

--- a/lib/rom/environment.rb
+++ b/lib/rom/environment.rb
@@ -62,7 +62,10 @@ module ROM
     #
     # @api public
     def schema(&block)
-      Schema.build(repositories, &block)
+      if block_given?
+        @schema = Schema.build(repositories, &block)
+      end
+      @schema
     end
 
     # Return registered relation

--- a/lib/rom/environment.rb
+++ b/lib/rom/environment.rb
@@ -73,6 +73,30 @@ module ROM
       @schema
     end
 
+    # Define mapping for relations
+    #
+    # @example
+    #
+    #   env.schema do
+    #     base_relation :users do
+    #       repository :test
+    #
+    #       attribute :id,        Integer
+    #       attribtue :user_name, String
+    #     end
+    #   end
+    #
+    #   env.mapping do
+    #     users do
+    #       model User
+    #
+    #       map :id
+    #       map :user_name, :to => :name
+    #     end
+    #   end
+    #
+    # @return [Mapping]
+    #
     # @api public
     def mapping(&block)
       Mapping.build(self, &block)

--- a/lib/rom/mapping.rb
+++ b/lib/rom/mapping.rb
@@ -33,7 +33,7 @@ module ROM
     # @return [Hash]
     #
     # @api public
-    def self.build(environment, schema, &block)
+    def self.build(environment, schema = environment.schema, &block)
       new(environment, schema, &block)
     end
 

--- a/lib/rom/mapping.rb
+++ b/lib/rom/mapping.rb
@@ -27,8 +27,8 @@ module ROM
     #   registry[:users]
     #   # #<ROM::Relation:0x000000025d3160>
     #
-    # @param [Environment, Hash] container with configured axiom relations
-    # @param [Hash] registry for rom relations
+    # @param [Environment] rom environment
+    # @param [Schema] rom schema
     #
     # @return [Hash]
     #

--- a/lib/rom/mapping.rb
+++ b/lib/rom/mapping.rb
@@ -5,6 +5,7 @@ module ROM
   # Builder DSL for ROM relations
   #
   class Mapping
+    include Adamantium::Flat
 
     attr_reader :environment, :schema, :model
     private :environment, :schema, :model

--- a/lib/rom/mapping.rb
+++ b/lib/rom/mapping.rb
@@ -73,7 +73,7 @@ module ROM
     # @api private
     def build_relation(relation, &block)
       definition = Definition.build(relation.header, &block)
-      environment.register(relation.name, Relation.build(relation, definition.mapper))
+      environment[relation.name] = Relation.build(relation, definition.mapper)
     end
 
   end # Mapping

--- a/lib/rom/mapping.rb
+++ b/lib/rom/mapping.rb
@@ -6,8 +6,8 @@ module ROM
   #
   class Mapping
 
-    attr_reader :env, :registry, :model
-    private :env, :model
+    attr_reader :environment, :schema, :model
+    private :environment, :schema, :model
 
     # Build ROM relations
     #
@@ -33,8 +33,8 @@ module ROM
     # @return [Hash]
     #
     # @api public
-    def self.build(env, registry = {}, &block)
-      new(env, registry, &block).registry
+    def self.build(environment, schema, &block)
+      new(environment, schema, &block)
     end
 
     # Initialize a new mapping instance
@@ -42,9 +42,9 @@ module ROM
     # @return [undefined]
     #
     # @api private
-    def initialize(env, registry, &block)
-      @env      = env
-      @registry = registry
+    def initialize(environment, schema, &block)
+      @environment = environment
+      @schema      = schema
       instance_eval(&block)
     end
 
@@ -56,7 +56,7 @@ module ROM
     #
     # @api private
     def method_missing(name, *, &block)
-      relation = env[name]
+      relation = schema[name]
 
       if relation
         build_relation(relation, &block)
@@ -71,8 +71,8 @@ module ROM
     #
     # @api private
     def build_relation(relation, &block)
-      definition              = Definition.build(relation.header, &block)
-      registry[relation.name] = Relation.build(relation, definition.mapper)
+      definition = Definition.build(relation.header, &block)
+      environment.register(relation.name, Relation.build(relation, definition.mapper))
     end
 
   end # Mapping

--- a/lib/rom/repository.rb
+++ b/lib/rom/repository.rb
@@ -52,7 +52,7 @@ module ROM
     # @return [self]
     #
     # @api private
-    def register(name, relation)
+    def []=(name, relation)
       adapter[name]   = relation
       relations[name] = adapter[name]
       self

--- a/lib/rom/repository.rb
+++ b/lib/rom/repository.rb
@@ -29,7 +29,7 @@ module ROM
     #
     #   repo = Repository.coerce(:test, 'in_memory://test')
     #   repo.register(:foo, [[:id, String], [:foo, String]])
-    #   repo.get(:foo)
+    #   repo[:foo]
     #
     #   # => <Axiom::Relation header=Axiom::Header ...>
     #
@@ -41,7 +41,7 @@ module ROM
     # @raise [KeyError]
     #
     # @api public
-    def get(name)
+    def [](name)
       relations.fetch(name)
     end
 

--- a/lib/rom/schema.rb
+++ b/lib/rom/schema.rb
@@ -6,7 +6,6 @@ module ROM
   #
   class Schema
     include Concord.new(:definition)
-    include Adamantium
 
     # Build a relation schema
     #
@@ -22,8 +21,8 @@ module ROM
     # @return [Schema]
     #
     # @api public
-    def self.build(&block)
-      new(Definition.new(&block))
+    def self.build(repositories, &block)
+      new(Definition.new(repositories, &block))
     end
 
     # Return defined relation identified by name

--- a/lib/rom/schema.rb
+++ b/lib/rom/schema.rb
@@ -38,14 +38,9 @@ module ROM
       definition[name]
     end
 
-    # Iterate over repositories and relations
-    #
-    # @return [Schema]
-    #
     # @api private
-    def each(&block)
-      definition.repositories.each(&block)
-      self
+    def call(&block)
+      definition.instance_eval(&block)
     end
 
   end # Schema

--- a/lib/rom/schema.rb
+++ b/lib/rom/schema.rb
@@ -5,7 +5,7 @@ module ROM
   # Schema builder DSL
   #
   class Schema
-    include Concord.new(:definition)
+    include Concord.new(:definition), Adamantium::Flat
 
     # Build a relation schema
     #

--- a/lib/rom/schema/definition.rb
+++ b/lib/rom/schema/definition.rb
@@ -36,7 +36,7 @@ module ROM
         relation   = Axiom::Relation::Base.new(name, base.header)
         repository = repositories.fetch(base.repository)
 
-        relations[name] = repository.register(name, relation).get(name)
+        relations[name] = repository.register(name, relation)[name]
 
         self
       end

--- a/lib/rom/schema/definition.rb
+++ b/lib/rom/schema/definition.rb
@@ -7,14 +7,14 @@ module ROM
     #
     # @private
     class Definition
-      include Equalizer.new(:relations)
+      include Equalizer.new(:repositories, :relations)
 
-      attr_reader :relations, :repositories
+      attr_reader :repositories, :relations
 
       # @api private
-      def initialize(&block)
+      def initialize(repositories, &block)
+        @repositories = repositories
         @relations    = {}
-        @repositories = {}
         instance_eval(&block) if block
       end
 
@@ -32,11 +32,11 @@ module ROM
       #
       # @api public
       def base_relation(name, &block)
-        base            = Relation::Base.new(&block)
-        relation        = Axiom::Relation::Base.new(name, base.header)
-        relations[name] = relation
+        base       = Relation::Base.new(&block)
+        relation   = Axiom::Relation::Base.new(name, base.header)
+        repository = repositories.fetch(base.repository)
 
-        (repositories[base.repository] ||= []) << relation
+        relations[name] = repository.register(name, relation).get(name)
 
         self
       end

--- a/lib/rom/schema/definition.rb
+++ b/lib/rom/schema/definition.rb
@@ -36,7 +36,8 @@ module ROM
         relation   = Axiom::Relation::Base.new(name, base.header)
         repository = repositories.fetch(base.repository)
 
-        relations[name] = repository.register(name, relation)[name]
+        repository[name] = relation
+        relations[name]  = repository[name]
 
         self
       end

--- a/spec/integration/environment_setup_spec.rb
+++ b/spec/integration/environment_setup_spec.rb
@@ -6,7 +6,7 @@ describe 'Setting up environment' do
   it 'registers relations within repositories' do
     env = ROM::Environment.coerce(memory: 'memory://test')
 
-    schema = Schema.build(env.repositories) do
+    schema = env.schema do
       base_relation :users do
         repository :memory
 

--- a/spec/integration/environment_setup_spec.rb
+++ b/spec/integration/environment_setup_spec.rb
@@ -4,7 +4,9 @@ require 'spec_helper'
 
 describe 'Setting up environment' do
   it 'registers relations within repositories' do
-    schema = ROM::Schema.build do
+    env = ROM::Environment.coerce(memory: 'memory://test')
+
+    schema = Schema.build(env.repositories) do
       base_relation :users do
         repository :memory
 
@@ -15,11 +17,6 @@ describe 'Setting up environment' do
       end
     end
 
-    env = ROM::Environment.coerce(memory: 'memory://test')
-    env.load_schema(schema)
-
-    repository = env.repository(:memory)
-
-    expect(repository.get(:users)).to eq(schema[:users])
+    expect(schema[:users]).to be_instance_of(Axiom::Relation::Variable)
   end
 end

--- a/spec/integration/mapping_relations_spec.rb
+++ b/spec/integration/mapping_relations_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe 'Defining relation mappings' do
   let!(:schema) {
-    Schema.build {
+    Schema.build(env.repositories) {
       base_relation :users do
         repository :test
 
@@ -17,7 +17,7 @@ describe 'Defining relation mappings' do
   }
 
   let!(:env) {
-    Environment.coerce(test: 'memory://test').load_schema(schema)
+    Environment.coerce(test: 'memory://test')
   }
 
   before do
@@ -29,7 +29,7 @@ describe 'Defining relation mappings' do
   end
 
   specify 'building registry of automatically mapped relations' do
-    registry = Mapping.build(env) {
+    Mapping.build(env, schema) {
       users do
         model User
 
@@ -38,7 +38,7 @@ describe 'Defining relation mappings' do
       end
     }
 
-    users = registry[:users]
+    users = env[:users]
 
     jane = User.new(id: 1, name: 'Jane')
 
@@ -51,9 +51,9 @@ describe 'Defining relation mappings' do
     custom_model  = mock_model(:id, :user_name)
     custom_mapper = TestMapper.new(schema[:users].header, custom_model)
 
-    registry = Mapping.build(env) { users { mapper(custom_mapper) } }
+    Mapping.build(env, schema) { users { mapper(custom_mapper) } }
 
-    users = registry[:users]
+    users = env[:users]
 
     jane = custom_model.new(id: 1, user_name: 'Jane')
 

--- a/spec/integration/mapping_relations_spec.rb
+++ b/spec/integration/mapping_relations_spec.rb
@@ -29,14 +29,14 @@ describe 'Defining relation mappings' do
   end
 
   specify 'building registry of automatically mapped relations' do
-    Mapping.build(env, schema) {
+    env.mapping do
       users do
         model User
 
         map :id
         map :user_name, to: :name
       end
-    }
+    end
 
     users = env[:users]
 
@@ -51,7 +51,7 @@ describe 'Defining relation mappings' do
     custom_model  = mock_model(:id, :user_name)
     custom_mapper = TestMapper.new(schema[:users].header, custom_model)
 
-    Mapping.build(env, schema) { users { mapper(custom_mapper) } }
+    env.mapping { users { mapper(custom_mapper) } }
 
     users = env[:users]
 

--- a/spec/integration/mapping_relations_spec.rb
+++ b/spec/integration/mapping_relations_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe 'Defining relation mappings' do
   let!(:schema) {
-    Schema.build(env.repositories) {
+    env.schema {
       base_relation :users do
         repository :test
 

--- a/spec/integration/schema_definition_spec.rb
+++ b/spec/integration/schema_definition_spec.rb
@@ -43,7 +43,7 @@ describe 'Defining a ROM schema' do
   let(:repository) { env.repository(:test) }
 
   let(:schema) do
-    ROM::Schema.build(env.repositories) do
+    env.schema do
       base_relation :people do
         repository :test
 

--- a/spec/integration/schema_definition_spec.rb
+++ b/spec/integration/schema_definition_spec.rb
@@ -63,7 +63,9 @@ describe 'Defining a ROM schema' do
         key :id
         key :person_id
       end
+    end
 
+    env.schema do
       relation :people_with_profile do
         people.join(profiles.rename(id: :profile_id, person_id: :id))
       end

--- a/spec/integration/schema_definition_spec.rb
+++ b/spec/integration/schema_definition_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe 'Defining a ROM schema' do
   let(:people) {
-    Axiom::Relation::Base.new(:people, people_header)
+    Axiom::Relation::Variable.new(Axiom::Relation::Base.new(:people, people_header))
   }
 
   let(:people_header) {
@@ -20,7 +20,7 @@ describe 'Defining a ROM schema' do
   }
 
   let(:profiles) {
-    Axiom::Relation::Base.new(:profiles, profiles_header)
+    Axiom::Relation::Variable.new(Axiom::Relation::Base.new(:profiles, profiles_header))
   }
 
   let(:profiles_header) {
@@ -39,10 +39,13 @@ describe 'Defining a ROM schema' do
     people.join(profiles.rename(id: :profile_id, person_id: :id))
   }
 
+  let(:env)        { Environment.coerce(test: 'memory://test') }
+  let(:repository) { env.repository(:test) }
+
   let(:schema) do
-    ROM::Schema.build do
+    ROM::Schema.build(env.repositories) do
       base_relation :people do
-        repository :postgres
+        repository :test
 
         attribute :id,   Integer
         attribute :name, String
@@ -51,7 +54,7 @@ describe 'Defining a ROM schema' do
       end
 
       base_relation :profiles do
-        repository :postgres
+        repository :test
 
         attribute :id,        Integer
         attribute :person_id, Integer

--- a/spec/integration/schema_definition_spec.rb
+++ b/spec/integration/schema_definition_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe 'Defining a ROM schema' do
   let(:people) {
-    Axiom::Relation::Variable.new(Axiom::Relation::Base.new(:people, people_header))
+    Axiom::Relation::Base.new(:people, people_header)
   }
 
   let(:people_header) {
@@ -20,7 +20,7 @@ describe 'Defining a ROM schema' do
   }
 
   let(:profiles) {
-    Axiom::Relation::Variable.new(Axiom::Relation::Base.new(:profiles, profiles_header))
+    Axiom::Relation::Base.new(:profiles, profiles_header)
   }
 
   let(:profiles_header) {
@@ -73,7 +73,7 @@ describe 'Defining a ROM schema' do
   end
 
   it 'registers the people relation' do
-    expect(schema[:people]).to eql(people)
+    expect(schema[:people]).to eq(people)
   end
 
   it 'establishes key attributes for people relation' do
@@ -85,10 +85,10 @@ describe 'Defining a ROM schema' do
   end
 
   it 'registers the profiles relation' do
-    expect(schema[:profiles]).to eql(profiles)
+    expect(schema[:profiles]).to eq(profiles)
   end
 
   it 'registers the people_with_profile relation' do
-    expect(schema[:people_with_profile]).to eql(people_with_profile)
+    expect(schema[:people_with_profile]).to eq(people_with_profile)
   end
 end

--- a/spec/integration/working_with_relations_spec.rb
+++ b/spec/integration/working_with_relations_spec.rb
@@ -21,7 +21,7 @@ describe 'Working with relations' do
 
     repo.register(:users, Axiom::Relation::Base.new(:users, header))
 
-    users = ROM::Relation.new(repo.get(:users), mapper)
+    users = ROM::Relation.new(repo[:users], mapper)
 
     user = model.new(id: 1, name: 'Jane')
     users.insert(user)

--- a/spec/integration/working_with_relations_spec.rb
+++ b/spec/integration/working_with_relations_spec.rb
@@ -19,7 +19,7 @@ describe 'Working with relations' do
     env  = ROM::Environment.coerce(test: 'memory://test')
     repo = env.repository(:test)
 
-    repo.register(:users, Axiom::Relation::Base.new(:users, header))
+    repo[:users] = Axiom::Relation::Base.new(:users, header)
 
     users = ROM::Relation.new(repo[:users], mapper)
 

--- a/spec/unit/rom/environment/element_reader_spec.rb
+++ b/spec/unit/rom/environment/element_reader_spec.rb
@@ -11,10 +11,10 @@ describe Environment, '#[]' do
     fake(:relation, name: :users) { Axiom::Relation::Base }
 
     before do
-      object.load_schema(test: [relation])
+      object.register(:users, relation)
     end
 
-    it { should be_instance_of(Axiom::Relation::Variable::Materialized) }
+    it { should be(relation) }
   end
 
   context 'when relation does not exist' do

--- a/spec/unit/rom/environment/element_reader_spec.rb
+++ b/spec/unit/rom/environment/element_reader_spec.rb
@@ -11,7 +11,7 @@ describe Environment, '#[]' do
     fake(:relation, name: :users) { Axiom::Relation::Base }
 
     before do
-      object.register(:users, relation)
+      object[:users] = relation
     end
 
     it { should be(relation) }

--- a/spec/unit/rom/mapping/class_methods/build_spec.rb
+++ b/spec/unit/rom/mapping/class_methods/build_spec.rb
@@ -5,21 +5,19 @@ require 'spec_helper'
 describe Mapping, '.build' do
   let(:header)   { [[:id, Integer], [:user_name, String], [:age, Integer], [:email, String]] }
   let(:relation) { Axiom::Relation::Base.new(:users, header) }
-  let(:env)      { Hash[users: relation] }
-  let(:registry) { Hash.new }
+  let(:env)      { Environment.coerce(test: 'memory://test') }
+  let(:schema)   { Hash[users: relation] }
 
   context 'when attribute mapping is used' do
-    subject do
-      Mapping.build(env, registry) do
+    subject { env }
+
+    before do
+      Mapping.build(env, schema) do
         users do
           map :id, :email
           map :user_name, to: :name
         end
       end
-    end
-
-    before do
-      stub(env).[](:users) { relation }
     end
 
     it 'registers rom relation' do
@@ -33,14 +31,8 @@ describe Mapping, '.build' do
     end
   end
 
-  context 'when registry is not injected' do
-    subject { Mapping.build(env) { } }
-
-    it { should be_instance_of(Hash) }
-  end
-
   context 'when unknown relation name is used' do
-    subject { described_class.build(env, registry) { not_here {} } }
+    subject { described_class.build(env, schema) { not_here {} } }
 
     it 'raises error' do
       expect { subject }.to raise_error(NoMethodError)

--- a/spec/unit/rom/repository/element_reader_spec.rb
+++ b/spec/unit/rom/repository/element_reader_spec.rb
@@ -14,7 +14,7 @@ describe Repository, '#[]' do
   let(:header)        { [] }
 
   before do
-    object.register(relation_name, relation)
+    object[relation_name] = relation
   end
 
   it { should eq(relation) }

--- a/spec/unit/rom/repository/element_reader_spec.rb
+++ b/spec/unit/rom/repository/element_reader_spec.rb
@@ -2,8 +2,8 @@
 
 require 'spec_helper'
 
-describe Repository, '#get' do
-  subject { object.get(relation_name) }
+describe Repository, '#[]' do
+  subject { object[relation_name] }
 
   let(:object) { described_class.build(name, uri) }
   let(:name)   { :bigdata }


### PR DESCRIPTION
This changes the way schema and mapping are being set up. Previously schema consisted of axiom relations and base relations, which wasn't very valuable. I changed it so that now schema actually registers relations within previously configured repositories. Each repository is using an adapter to establish its relations.

This is a really nice change as it simplifies setup. I also added `Environment#schema` and `Environment#mapping` to make things even simpler.
